### PR TITLE
Udpate github actions to fix warnings

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,19 +8,19 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32
+        uses: docker/setup-buildx-action@v3.0.0
         with:
           buildkitd-flags: --debug
 
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@v4
 
       - name: Create output dir
         run: |
           mkdir -p apk
 
       - name: Build
-        uses: docker/build-push-action@9379083e426e2e84abb80c8c091f5cdeb7d3fd7a
+        uses: docker/build-push-action@v5
         with:
           file: android/Dockerfile
           context: .

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,13 +27,13 @@ jobs:
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
+        uses: actions/upload-artifact@v3
         with:
           name: apk
           path: apk/apolloui-prod-release-unsigned.apk
 
       - name: Upload mapping
-        uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
+        uses: actions/upload-artifact@v3
         with:
           name: mapping
           path: apk/mapping.txt

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3
 
         with:
           buildkitd-flags: --debug

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
+        uses: actions/upload-artifact@v3
         with:
           name: apk
           path: apk/apolloui-prod-release-unsigned.apk

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,8 +4,8 @@ jobs:
   pr:
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v3.0.0
 
         with:
           buildkitd-flags: --debug

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,12 +5,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32
+        uses: docker/setup-buildx-action@v3.0.0
+
         with:
           buildkitd-flags: --debug
 
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: checkout@v4
 
       # https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.5
       - name: Validate Gradle wrapper
@@ -21,7 +22,7 @@ jobs:
           mkdir -p apk
 
       - name: Build
-        uses: docker/build-push-action@9379083e426e2e84abb80c8c091f5cdeb7d3fd7a
+        uses: docker/build-push-action@v5
         with:
           file: android/Dockerfile
           context: .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
           buildkitd-flags: --debug
 
       - name: Checkout
-        uses: checkout@v4
+        uses: actions/checkout@v4
 
       # https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.5
       - name: Validate Gradle wrapper


### PR DESCRIPTION
Warnings about depreacted `save-state` and `set-output`. But also about node12 which is deprecated and will be forced to run on node16